### PR TITLE
Bump log4j-core from 2.12.1 to 2.13.2 in /Collections_List

### DIFF
--- a/Collections_List/pom.xml
+++ b/Collections_List/pom.xml
@@ -30,7 +30,7 @@
 	<dependency>
     	<groupId>org.apache.logging.log4j</groupId>
     	<artifactId>log4j-core</artifactId>
-    	<version>2.12.1</version>
+    	<version>2.13.2</version>
 	</dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
 	<dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.12.1 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>